### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
         "alpinejs": "^3.9.6",
         "autoprefixer": "^10.4.4",
         "axios": "^0.25",
-        "laravel-vite-plugin": "^0.2.4",
+        "laravel-vite-plugin": "^0.2.2",
         "lodash": "^4.17.19",
         "postcss": "^8.4.12",
         "tailwindcss": "^3.0.23",
-        "vite": "^2.9.13"
+        "vite": "^2.9.12"
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,16 +7,5 @@ export default defineConfig({
             'resources/css/app.css',
             'resources/js/app.js',
         ]),
-        {
-            name: 'blade',
-            handleHotUpdate({ file, server }) {
-                if (file.endsWith('.blade.php')) {
-                    server.ws.send({
-                        type: 'full-reload',
-                        path: '*',
-                    });
-                }
-            },
-        },
     ],
 });


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-65166` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
